### PR TITLE
Refactor business site and add blog framework

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,128 +1,91 @@
-/* Reset & base styles */
+/* Base reset */
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-  
-  body {
-    font-family: 'Inter', sans-serif;
-    background: #f9f9fb;
-    color: #111;
-    line-height: 1.6;
-  }
-  
-  .container {
-    width: 90%;
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 2rem 0;
-  }
-  
-  /* Hero section */
-  .hero {
-    background: linear-gradient(135deg, #4338ca, #6366f1);
-    color: white;
-    padding: 4rem 0;
-    text-align: center;
-  }
-  
-  .hero h1 {
-    font-size: 2.8rem;
-    font-weight: 700;
-    margin-bottom: 1rem;
-  }
-  
-  .subtitle {
-    font-size: 1.25rem;
-    margin-bottom: 2rem;
-  }
-  
-  .cta {
-    background: white;
-    color: #4338ca;
-    padding: 0.75rem 1.5rem;
-    font-weight: 600;
-    border-radius: 8px;
-    text-decoration: none;
-    transition: background 0.3s ease;
-  }
-  
-  .cta:hover {
-    background: #e0e0ff;
-  }
-  
-  /* Sections */
-  section {
-    padding: 3rem 0;
-  }
-  
-  .services .grid {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-    margin-top: 2rem;
-  }
-  
-  @media (min-width: 768px) {
-    .services .grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    }
-  }
-    
-  .card {
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 12px;
-    padding: 2rem;
-    text-align: center;
-    font-weight: 600;
-    box-shadow: 0 4px 8px rgba(0,0,0,0.04);
-  }
-  
-  /* Difference list */
-  .difference ul {
-    list-style: none;
-    padding-left: 0;
-    margin-top: 1.5rem;
-  }
-  
-  .difference li {
-    margin-bottom: 1rem;
-    padding-left: 1.2rem;
-    position: relative;
-  }
-  
-  .difference li::before {
-    content: "✔️";
-    position: absolute;
-    left: 0;
-  }
-  
-  /* CTA final */
-  .cta-final {
-    background: #6366f1;
-    color: white;
-    text-align: center;
-    padding: 4rem 0;
-  }
-  
-  footer {
-    background: #111827;
-    color: white;
-    text-align: center;
-    padding: 2rem 0;
-    font-size: 0.9rem;
-  }
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
 
-  .card i {
-    margin-bottom: 1rem;
-    color: #6366f1;
-  }
+body {
+  font-family: 'Libre Caslon Text', serif;
+  line-height: 1.6;
+  color: #111;
+  background: #ffffff;
+}
 
-  .difference li i {
-    margin-right: 0.5rem;
-    color: #6366f1;
-  }
-      
+h1, h2, h3, h4 {
+  font-family: 'Cormorant Garamond', serif;
+  font-weight: 600;
+}
+
+.container {
+  width: 90%;
+  max-width: 850px;
+  margin: 0 auto;
+  padding: 2rem 0;
+}
+
+.hero {
+  padding: 6rem 0 4rem;
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+}
+
+.tagline {
+  font-size: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.cta, .secondary-cta {
+  display: inline-block;
+  margin: 0.5rem 0.25rem;
+  padding: 0.75rem 1.5rem;
+  text-decoration: none;
+  color: #fff;
+  background: #111;
+  border-radius: 4px;
+  transition: background 0.3s ease;
+}
+
+.secondary-cta {
+  background: #666;
+}
+
+.cta:hover, .secondary-cta:hover {
+  background: #333;
+}
+
+section {
+  padding: 3rem 0;
+}
+
+.page-header {
+  text-align: center;
+  padding: 4rem 0 2rem;
+}
+
+.post-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.post-list li {
+  margin-bottom: 1.5rem;
+  font-size: 1.25rem;
+}
+
+.post-date {
+  display: block;
+  font-size: 0.875rem;
+  color: #555;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 0;
+  background: #f0f0f0;
+  font-size: 0.9rem;
+}

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog | Kraftech Consulting</title>
+  <meta name="description" content="Insights on AI and automation for business.">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="page-header">
+    <div class="container">
+      <h1>Insights & Case Studies</h1>
+      <p>Weekly perspectives on automation and workflow architecture.</p>
+    </div>
+  </header>
+
+  <main class="container">
+    <ul class="post-list">
+      <li>
+        <a href="post-template.html">Example Post Title</a>
+        <span class="post-date">Jan 1, 2025</span>
+      </li>
+    </ul>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 J. Adam Kraft – Kraftech Consulting</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/content/blog.md
+++ b/content/blog.md
@@ -1,0 +1,10 @@
+---
+title: "Example Post Title"
+date: 2025-01-01
+tags: [automation, ai]
+summary: |
+  A short overview of how automated workflows saved hours for a client.
+video: https://www.youtube.com/embed/VIDEOID
+---
+
+Write your article in Markdown here. This file serves as a placeholder for future posts.

--- a/index.html
+++ b/index.html
@@ -1,366 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- Primary Meta Tags -->
-  <title>Kraftech | Elite IT Automation for Business</title>
-  <meta name="title" content="Kraftech | Elite IT Automation for Business">
-  <meta name="description" content="Transform your business with AI, automation, and secure cloud infrastructure. Kraftech is the elite MSP built for modern business.">
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="assets/css/style.css" />
-  <!-- Modal & form styles -->
-  <link rel="stylesheet" href="assets/css/form.css" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kraftech Consulting | AI & Automation</title>
+  <meta name="description" content="AI and workflow automation consulting by J. Adam Kraft.">
+  <link rel="stylesheet" href="assets/css/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  
-  <!-- Bootstrap CSS -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-
-  <!-- AOS Scroll Animation -->
-  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
-
-
-  <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://business.kraftech.co/">
-  <meta property="og:title" content="Kraftech | Elite IT Automation for Business">
-  <meta property="og:description" content="Transform your business with AI, automation, and secure cloud infrastructure.">
-  <meta property="og:image" content="https://business.kraftech.co/assets/images/preview.png">
-
-  <!-- X -->
-  <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://business.kraftech.co/">
-  <meta property="twitter:title" content="Kraftech | Elite IT Automation for Business">
-  <meta property="twitter:description" content="Transform your business with AI, automation, and secure cloud infrastructure.">
-  <meta property="twitter:image" content="https://business.kraftech.co/assets/images/preview.png">
-
-<!-- Favicon (Optional) -->
-<link rel="icon" href="favicon.ico" type="image/x-icon">
-
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
 </head>
 <body>
   <header class="hero">
     <div class="container">
-      <h1>Elite IT. Built for Automation.</h1>
-      <p class="subtitle">
-        From AI workflows to zero-trust security, Kraftech transforms your IT from overhead to advantage.
-      </p>
-      <a href="#contact" class="cta">Book a Discovery Call</a>
+      <h1>Kraftech Consulting</h1>
+      <p class="tagline">AI & workflow architecture for modern teams</p>
+      <p>I design automation systems that free your team to focus on what matters.</p>
+      <a href="mailto:consult@kraftech.co" class="cta">Book a Consultation</a>
+      <a href="blog.html" class="secondary-cta">Explore Insights</a>
     </div>
   </header>
 
-  <section class="services" data-aos="fade-up">
+  <section class="about">
     <div class="container">
-      <h2>What We Do Best</h2>
-      <div class="grid">
-        <div class="card service-card" data-bs-toggle="modal" data-bs-target="#aiModal">
-            <div class="card-body text-center">
-              <i class="fas fa-robot fa-2x mb-3"></i>
-              <h5 class="card-title">AI Workflows & Automation</h5>
-              <p class="card-text">Smarter systems that save you time and money.</p>
-            </div>
-          </div>
-          <div class="card service-card" data-bs-toggle="modal" data-bs-target="#m365Modal">
-            <div class="card-body text-center">
-              <i class="fas fa-diagram-project fa-2x mb-3"></i>
-              <h5 class="card-title">Microsoft 365 Modern Workplace</h5>
-              <p class="card-text">Secure, efficient, cloud-first environments built for productivity.</p>
-            </div>
-          </div>
-          <div class="card service-card" data-bs-toggle="modal" data-bs-target="#cyberModal">
-            <div class="card-body text-center">
-              <i class="fas fa-eye-slash fa-2x mb-3"></i>
-              <h5 class="card-title">Cybersecurity & Compliance</h5>
-              <p class="card-text">Harden your defenses and meet compliance head-on.</p>
-            </div>
-          </div>          
-          <div class="card service-card" data-bs-toggle="modal" data-bs-target="#networksModal">
-            <div class="card-body text-center">
-              <i class="fas fa-network-wired fa-2x mb-3"></i>
-              <h5 class="card-title">Smarter Networks & Cloud</h5>
-              <p class="card-text">Connect, secure, and scale across every location.</p>
-            </div>
-          </div>          
-          <div class="card service-card" data-bs-toggle="modal" data-bs-target="#ctoModal">
-            <div class="card-body text-center">
-              <i class="fas fa-chess-king fa-2x mb-3"></i>
-              <h5 class="card-title">Fractional CTO Services</h5>
-              <p class="card-text">Executive IT strategy without the full-time overhead.</p>
-            </div>
-          </div>          
-      </div>
+      <h2>Build Smarter Systems</h2>
+      <p>From strategy to implementation, I help businesses use AI to optimize processes and unlock new value. Need inspiration? Visit <a href="https://jadamkraft.com">jadamkraft.com</a> for my creative archive.</p>
     </div>
   </section>
-
-  <section class="impact" data-aos="fade-up">
-    <div class="container">
-      <h2>Real Impact</h2>
-      <p>We’ve helped businesses in law, retail, and hospitality reclaim their time with automation and secure infrastructure.</p>
-    </div>
-  </section>
-
-  <section class="difference" data-aos="fade-up">
-    <div class="container">
-      <h2>Why Kraftech</h2>
-      <ul>
-        <li><i class="fas fa-gears"></i> Built-in automation, not an afterthought</li>
-        <li><i class="fas fa-handshake"></i> Transparent, client-first model</li>
-        <li><i class="fas fa-lock"></i> Cybersecurity baked in from day one</li>
-        <li><i class="fas fa-user-gear"></i> Advice from a real engineer, not a sales rep</li>
-      </ul>
-    </div>
-  </section>
-
-  <section class="cta-final" id="contact" data-aos="fade-up">
-    <div class="container">
-      <h2>Let’s Talk</h2>
-      <p>Ready to streamline your IT and future-proof your business?</p>
-    </div>
-  </section>
-
-  <!-- <div class="sticky-cta">
-    <a href="#contact" class="cta">Book a Discovery Call</a>
-  </div> -->
-
-  <!-- Sticky CTA Button -->
-<button id="stickyCta" class="sticky-cta">Start Your Solution</button>
-
-<!-- Modal -->
-<div id="contactModal" class="kraftech-modal hidden">
-  <div class="modal-content">
-    <span class="close-button">&times;</span>
-    <h2>Let's Build Smarter IT</h2>
-    <form id="leadForm" method="POST" action="https://formspree.io/f/xovdvvnd">
-      <input type="text" name="name" placeholder="Your Name" required />
-      <input type="email" name="email" placeholder="Email" required />
-      <input type="text" name="company" placeholder="Company Name" />
-      <input type="text" name="_gotcha" style="display:none" />
-      <input type="hidden" name="_subject" value="New Lead from business.kraftech.co" />
-      <input type="hidden" name="_redirect" value="https://business.kraftech.co/thank-you.html" />
-      <select name="interest">
-        <option value="">What are you looking for?</option>
-        <option value="automation">AI & Automation</option>
-        <option value="m365">Modern Workplace</option>
-        <option value="networking">Smarter Networks</option>
-        <option value="cloud">Cloud Strategy</option>
-        <option value="cto">Fractional CTO</option>
-      </select>
-      <textarea name="message" placeholder="Describe your needs..." required></textarea>
-      <input type="text" name="_gotcha" style="display:none" />
-      <button type="submit">Send</button>
-    </form>
-  </div>
-</div>
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Kraftech. Built by humans using automation.</p>
+      <p>&copy; 2025 J. Adam Kraft – Kraftech Consulting</p>
     </div>
   </footer>
 
-    <!-- AI Modal -->
-<div class="modal fade" id="aiModal" tabindex="-1" aria-labelledby="aiModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-lg">
-      <div class="modal-content shadow-lg rounded-4">
-        <div class="modal-header border-0">
-          <h5 class="modal-title" id="aiModalLabel">Smarter Systems, Less Stress</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body py-4 px-5">
-          <p class="lead">At Kraftech, we design intelligent workflows and automation tailored to <strong>your</strong> business. From repetitive task elimination to AI-driven insights, we make your tech work harder—so you don’t have to.</p>
-          
-          <ul class="list-unstyled mt-4">
-            <li class="mb-2">🚀 Automate emails, reports, and approvals</li>
-            <li class="mb-2">📊 Use AI for real-time decision-making</li>
-            <li class="mb-2">🔐 Maintain security and compliance</li>
-            <li class="mb-2">💰 Save hours weekly — and reduce costs</li>
-          </ul>
-  
-          <hr class="my-4">
-  
-          <h6 class="fw-semibold">Use Cases</h6>
-          <p class="mb-2"><strong>Law Firm:</strong> Auto-route sensitive emails using Microsoft Purview & Power Automate.</p>
-          <p class="mb-2"><strong>Retail:</strong> AI-powered inventory predictions tied to sales + weather patterns.</p>
-          <p><strong>IT Teams:</strong> Auto-triage helpdesk tickets with Teams & Chatbots.</p>
-  
-          <blockquote class="blockquote my-4 ps-3 border-start border-3">
-            “We used to spend hours manually processing reports. Kraftech cut that to minutes.”<br>
-            <footer class="blockquote-footer mt-1">Operations Manager, DVL Bar</footer>
-          </blockquote>
-  
-          <div class="text-center mt-4">
-            <a href="mailto:support@kraftech.co" class="btn btn-primary btn-lg px-4">Book a Discovery Call</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Microsoft 365 Modern Workplace Modal -->
-<div class="modal fade" id="m365Modal" tabindex="-1" aria-labelledby="m365ModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-lg">
-      <div class="modal-content shadow-lg rounded-4">
-        <div class="modal-header border-0">
-          <h5 class="modal-title" id="m365ModalLabel">Empower Your Team with the Modern Workplace</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body py-4 px-5">
-          <p class="lead">Modern work isn’t about offices — it’s about outcomes. Kraftech delivers secure, cloud-first Microsoft 365 environments that help your team collaborate, automate, and thrive — no matter where they work.</p>
-  
-          <ul class="list-unstyled mt-4">
-            <li class="mb-2">🔐 Enforce compliance with Microsoft Purview & Entra ID</li>
-            <li class="mb-2">📱 Enroll and secure devices with Intune & Autopilot</li>
-            <li class="mb-2">🤖 Automate onboarding, approvals & alerts with Power Automate</li>
-            <li class="mb-2">📂 Migrate legacy file shares into SharePoint with versioning & access controls</li>
-            <li class="mb-2">🛠 Full admin of Exchange Online, Teams, Defender, and the Microsoft 365 suite</li>
-          </ul>
-  
-          <hr class="my-4">
-  
-          <h6 class="fw-semibold">Use Cases</h6>
-          <p class="mb-2"><strong>Law Firm:</strong> Set up sensitivity labels, retention policies, and zero-trust access to client files.</p>
-          <p class="mb-2"><strong>Multi-State Retail:</strong> Onboard iPads and Windows laptops using Apple Business Manager + Intune Autopilot.</p>
-          <p><strong>Corporate IT:</strong> Configure Power Automate flows for IT ticket triage, HR onboarding, and security escalations.</p>
-  
-          <blockquote class="blockquote my-4 ps-3 border-start border-3">
-            “Kraftech took our Microsoft 365 deployment from confusing to confident. We’re fully cloud-first now — and finally secure.”<br>
-            <footer class="blockquote-footer mt-1">IT Director, Regional Law Firm</footer>
-          </blockquote>
-  
-          <div class="text-center mt-4">
-            <a href="mailto:support@kraftech.co" class="btn btn-primary btn-lg px-4">Book a Microsoft 365 Consultation</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Cybersecurity & Compliance Modal -->
-<div class="modal fade" id="cyberModal" tabindex="-1" aria-labelledby="cyberModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-lg">
-      <div class="modal-content shadow-lg rounded-4">
-        <div class="modal-header border-0">
-          <h5 class="modal-title" id="cyberModalLabel">Defend What Matters Most</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body py-4 px-5">
-          <p class="lead">Kraftech helps businesses protect data, enforce policies, and recover fast when threats strike. Our layered security approach combines Microsoft 365 Defender, Entra ID, and cloud-native tools with practical policies tailored to your risk profile.</p>
-  
-          <ul class="list-unstyled mt-4">
-            <li class="mb-2">🛡️ Deploy Microsoft Defender for Endpoint & Email</li>
-            <li class="mb-2">🔐 Enforce MFA, Conditional Access & Entra policies</li>
-            <li class="mb-2">📜 Configure Microsoft Purview DLP, retention, and sensitivity labels</li>
-            <li class="mb-2">🔎 Monitor attack patterns using Entra sign-in logs and threat reports</li>
-            <li class="mb-2">📦 Set up Zero Trust principles — including device health and location filtering</li>
-          </ul>
-  
-          <hr class="my-4">
-  
-          <h6 class="fw-semibold">Use Cases</h6>
-          <p class="mb-2"><strong>Professional Services:</strong> Audit email forwarding rules to block malicious auto-forwarding to attackers.</p>
-          <p class="mb-2"><strong>Multi-site Enterprises:</strong> Segment networks and enforce geo-fencing for conditional access.</p>
-          <p><strong>Executive Teams:</strong> Enable targeted protection with Defender & Purview auto-labeling policies.</p>
-  
-          <blockquote class="blockquote my-4 ps-3 border-start border-3">
-            “Kraftech spotted and shut down an email breach before it reached our execs. Their response time saved us.”<br>
-            <footer class="blockquote-footer mt-1">Managing Partner, Wilkin Law</footer>
-          </blockquote>
-  
-          <div class="text-center mt-4">
-            <a href="mailto:support@kraftech.co" class="btn btn-primary btn-lg px-4">Book a Security Risk Assessment</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Smarter Networks & Cloud Modal -->
-<div class="modal fade" id="networksModal" tabindex="-1" aria-labelledby="networksModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-lg">
-      <div class="modal-content shadow-lg rounded-4">
-        <div class="modal-header border-0">
-          <h5 class="modal-title" id="networksModalLabel">Smarter Networks, Stronger Business</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body py-4 px-5">
-          <p class="lead">Your network is the backbone of your business. We design, secure, and manage high-performance cloud-connected networks tailored for modern work — from edge to cloud to home office.</p>
-  
-          <ul class="list-unstyled mt-4">
-            <li class="mb-2">🌐 Design hybrid cloud infrastructure with Azure, AWS & on-prem sync</li>
-            <li class="mb-2">🔌 Configure Ubiquiti UniFi and EdgeMax for secure VLAN routing</li>
-            <li class="mb-2">🛰️ Deploy ZeroTier VPN for seamless, secure multi-location access</li>
-            <li class="mb-2">🚦 Optimize traffic flows, QoS, and firewall policies</li>
-            <li class="mb-2">📡 Support mobile and remote teams with robust Wi-Fi and routing</li>
-          </ul>
-  
-          <hr class="my-4">
-  
-          <h6 class="fw-semibold">Use Cases</h6>
-          <p class="mb-2"><strong>Retail Chains:</strong> Link multiple locations using ZeroTier with centralized management.</p>
-          <p class="mb-2"><strong>Legal Offices:</strong> Separate Wi-Fi, admin, and client traffic via UniFi VLANs and firewall segmentation.</p>
-          <p><strong>Remote Teams:</strong> Automatically route traffic through encrypted tunnels without user interaction.</p>
-  
-          <blockquote class="blockquote my-4 ps-3 border-start border-3">
-            “Kraftech connected our offices in three states into one seamless system. Remote access is faster and safer than ever.”<br>
-            <footer class="blockquote-footer mt-1">Director of Ops, Altitude Brands</footer>
-          </blockquote>
-  
-          <div class="text-center mt-4">
-            <a href="mailto:support@kraftech.co" class="btn btn-primary btn-lg px-4">Get a Network Review</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Fractional CTO Modal -->
-<div class="modal fade" id="ctoModal" tabindex="-1" aria-labelledby="ctoModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-lg">
-      <div class="modal-content shadow-lg rounded-4">
-        <div class="modal-header border-0">
-          <h5 class="modal-title" id="ctoModalLabel">Enterprise IT Leadership, On Demand</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body py-4 px-5">
-          <p class="lead">Whether you're scaling, restructuring, or launching something new, Kraftech provides experienced IT leadership to guide your roadmap, manage vendors, and future-proof your business — without the cost of a full-time CTO.</p>
-  
-          <ul class="list-unstyled mt-4">
-            <li class="mb-2">📊 Align IT investments with business goals and growth stages</li>
-            <li class="mb-2">🧭 Lead digital transformation & cloud migration strategies</li>
-            <li class="mb-2">🧩 Select, evaluate, and manage third-party vendors and MSPs</li>
-            <li class="mb-2">🛡️ Oversee IT compliance, security, and risk frameworks</li>
-            <li class="mb-2">📈 Coach internal staff or help hire and develop your IT team</li>
-          </ul>
-  
-          <hr class="my-4">
-  
-          <h6 class="fw-semibold">Use Cases</h6>
-          <p class="mb-2"><strong>Startups:</strong> Build the right tech stack from day one without over-investing in tools or staff.</p>
-          <p class="mb-2"><strong>SMBs:</strong> Navigate growing pains, implement systems, and scale operations securely.</p>
-          <p><strong>Multi-site Firms:</strong> Centralize infrastructure strategy while respecting regional autonomy.</p>
-  
-          <blockquote class="blockquote my-4 ps-3 border-start border-3">
-            “We needed someone who could step in and steer the ship. Kraftech gave us the clarity and direction we didn’t know we were missing.”<br>
-            <footer class="blockquote-footer mt-1">CEO, Regional Tech Startup</footer>
-          </blockquote>
-  
-          <div class="text-center mt-4">
-            <a href="mailto:support@kraftech.co" class="btn btn-primary btn-lg px-4">Schedule a Strategy Session</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-        
-  <script src="assets/js/script.js"></script>
-  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
-  <script>
-    AOS.init();
-  </script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="assets/js/modal.js"></script>
-
+  <script src="scripts/update-homepage.js" defer></script>
 </body>
 </html>

--- a/post-template.html
+++ b/post-template.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Post Title | Kraftech Consulting</title>
+  <meta name="description" content="Post summary here.">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="page-header">
+    <div class="container">
+      <h1>Post Title</h1>
+      <p class="post-date">January 1, 2025 • Tags: automation, ai</p>
+    </div>
+  </header>
+
+  <main class="container">
+    <p>Post summary paragraph that introduces the key lessons.</p>
+    <div class="video-wrapper" style="margin:2rem 0;">
+      <iframe width="560" height="315" src="https://www.youtube.com/embed/VIDEOID" title="Video" frameborder="0" allowfullscreen></iframe>
+    </div>
+    <p>Full article content written in HTML or generated from markdown.</p>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 J. Adam Kraft – Kraftech Consulting</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/scripts/update-homepage.js
+++ b/scripts/update-homepage.js
@@ -1,0 +1,2 @@
+// Placeholder for future automation.
+// This script will update the homepage with the latest video or case study.


### PR DESCRIPTION
## Summary
- redesign homepage with concise consulting messaging and CTA
- implement blog index and post template pages
- simplify typography using Libre Caslon Text and Cormorant Garamond
- provide example Markdown post and placeholder automation script

## Testing
- `tidy -q index.html 2>&1 | head -n 5`
- `tidy -q blog.html 2>&1 | head -n 5`
- `tidy -q post-template.html 2>&1 | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_687d600f6f54832292c51338a772af32