### PR TITLE
Add build-time blog generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Kraftech Consulting Site
+
+## Local Blog Build
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Generate static blog pages and update the index:
+   ```bash
+   npm run build
+   ```
+
+Markdown posts live under `content/blog/`. Published posts render to static HTML files in the repository root.
+

--- a/blog.html
+++ b/blog.html
@@ -29,8 +29,12 @@
   <main class="container">
     <ul class="post-list">
       <li class="featured">
+        <a href="kraftech-co-gen-x-tech.html">kraftech.co | Gen X Tech</a>
+        <span class="post-date">Aug 15, 2025</span> <span class="badge">Featured</span>
+      </li>
+      <li>
         <a href="example-post-title.html">Example Post Title</a>
-        <span class="post-date">Jan 1, 2025</span> <span class="badge">Featured</span>
+        <span class="post-date">Jan 1, 2025</span> 
       </li>
     </ul>
   </main>

--- a/example-post-title.html
+++ b/example-post-title.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Example Post Title | Kraftech Consulting</title>
+  <meta name="description" content="A short overview of how automated workflows saved hours for a client.">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="page-header">
+    <div class="container">
+      <h1>Example Post Title</h1>
+      <p class="post-date">Jan 1, 2025 • Tags: automation, ai</p>
+    </div>
+  </header>
+
+  <main class="container">
+    <p>A short overview of how automated workflows saved hours for a client.</p>
+    <div class="video-wrapper" style="margin:2rem 0;">
+         <iframe src="https://iframe.videodelivery.net/VIDEOID" title="Video" allow="autoplay; encrypted-media" allowfullscreen frameborder="0"></iframe>
+       </div>
+    <div class="post-body"><p>Write your article in <strong>Markdown</strong> here…</p>
+</div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 J. Adam Kraft – Kraftech Consulting</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/kraftech-co-gen-x-tech.html
+++ b/kraftech-co-gen-x-tech.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>kraftech.co | Gen X Tech | Kraftech Consulting</title>
+  <meta name="description" content="A 52 second promotional video for kraftech.co.">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="page-header">
+    <div class="container">
+      <h1>kraftech.co | Gen X Tech</h1>
+      <p class="post-date">Aug 15, 2025 • Tags: automation, ai</p>
+    </div>
+  </header>
+
+  <main class="container">
+    <p>A 52 second promotional video for kraftech.co.</p>
+    <div class="video-wrapper" style="margin:2rem 0;">
+         <iframe src="https://iframe.videodelivery.net/0d98c6ca61963ec7ebef82d7bf2636d0" title="Video" allow="autoplay; encrypted-media" allowfullscreen frameborder="0"></iframe>
+       </div>
+    <div class="post-body"><p>This is the journey of a Gen X technologist from birth to AI revolution…</p>
+</div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 J. Adam Kraft – Kraftech Consulting</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/scripts/build-blog.js
+++ b/scripts/build-blog.js
@@ -26,6 +26,7 @@ const sanitize = (html) =>
       '*': ['id', 'class']
     },
     allowedSchemes: ['http', 'https', 'mailto'],
+    allowedIframeHostnames: ['iframe.videodelivery.net'],
     transformTags: {
       a: (tagName, attribs) => ({
         tagName: 'a',
@@ -45,7 +46,25 @@ function slugify(title) {
 
 if (!fs.existsSync(blogDir)) fs.mkdirSync(blogDir, { recursive: true });
 if (!fs.existsSync(templatePath)) throw new Error('Missing templates/post-template.html');
-if (!fs.existsSync(blogListPage)) throw new Error('Missing blog.html list page');
+if (!fs.existsSync(blogListPage)) {
+  console.warn('blog.html not found, creating a minimal placeholder.');
+  const minimal = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog | Kraftech Consulting</title>
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+  <h1>Blog</h1>
+  <main class="container">
+    <ul class="post-list"></ul>
+  </main>
+</body>
+</html>`;
+  fs.writeFileSync(blogListPage, minimal, 'utf8');
+}
 
 const template = fs.readFileSync(templatePath, 'utf8');
 


### PR DESCRIPTION
## Summary
- sanitize and render markdown posts to static HTML
- auto-create blog page when missing and update index list
- document local build process

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fb47bf6d8832298b87b61200d900d