### PR TITLE
feat: add cloudflare video hero background

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -60,15 +60,19 @@ blockquote {
   color: #fff;
   overflow: hidden;
 }
-.hero-bg {
+.hero-bg,
+.hero-fallback {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
-  filter: blur(6px);
-  z-index: -2;
+  filter: blur(2px);
+  z-index: 0;
+}
+.hero-fallback {
+  z-index: -1;
 }
 
 .overlay {
@@ -77,8 +81,13 @@ blockquote {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0,0,0,0.5);
-  z-index: -1;
+  background: rgba(0,0,0,0.35);
+  z-index: 0;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
 }
 
 .hero-content h1 {

--- a/index.html
+++ b/index.html
@@ -20,9 +20,13 @@
     </ul>
   </nav>
   <header class="hero" id="home">
-    <video class="hero-bg" autoplay muted loop playsinline>
-      <source src="assets/images/hero-bg.mp4" type="video/mp4">
-    </video>
+    <img src="/assets/hero-fallback.jpg" alt="" class="hero-fallback" />
+    <iframe
+      class="hero-bg"
+      src="https://iframe.videodelivery.net/42c8ee298e67bd8b365e072a4b5fafda?autoplay=true&muted=true&loop=true"
+      allow="autoplay; fullscreen; picture-in-picture"
+      loading="lazy"
+    ></iframe>
     <div class="overlay"></div>
     <div class="container hero-content">
       <h1>AI Workflows. Automated Success.</h1>
@@ -75,6 +79,24 @@
         const expanded = toggle.getAttribute('aria-expanded') === 'true' || false;
         toggle.setAttribute('aria-expanded', !expanded);
       });
+    }
+  </script>
+  <script>
+    const bgVideo = document.querySelector('.hero-bg');
+    const fallbackImg = document.querySelector('.hero-fallback');
+    if (bgVideo && fallbackImg) {
+      let loaded = false;
+      bgVideo.addEventListener('load', () => {
+        loaded = true;
+      });
+      bgVideo.addEventListener('error', () => {
+        bgVideo.style.display = 'none';
+      });
+      setTimeout(() => {
+        if (!loaded) {
+          bgVideo.style.display = 'none';
+        }
+      }, 4000);
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- replace static hero background with Cloudflare Stream video and fallback image
- adjust hero styles for subtle blur and overlay
- add JS fallback when video fails to load

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fd1712a108322a929d9fc4508cdc6