### PR TITLE
Revamp hero, navigation and contact flow

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -100,6 +100,18 @@ blockquote {
   margin-bottom: 2rem;
 }
 
+.value-bullets {
+  list-style: disc;
+  margin: 1rem auto 2rem;
+  padding-left: 1.25rem;
+  text-align: left;
+  max-width: 600px;
+}
+
+.value-bullets li {
+  margin-bottom: 0.5rem;
+}
+
 .cta-button {
   display: inline-block;
   padding: 0.75rem 1.5rem;
@@ -107,7 +119,9 @@ blockquote {
   color: #fff;
   text-decoration: none;
   border-radius: 4px;
+  border: none;
   transition: background 0.3s ease;
+  cursor: pointer;
 }
 
 .cta-button:hover,
@@ -294,4 +308,52 @@ footer {
   padding: 2rem 0;
   background: #f0f0f0;
   font-size: 0.9rem;
+}
+
+/* contact form */
+.contact-form {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.contact-form .form-group {
+  margin-bottom: 1rem;
+}
+
+.contact-form label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.contact-form input,
+.contact-form textarea,
+.contact-form select {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.contact-form textarea {
+  min-height: 120px;
+}
+
+.contact-form .consent {
+  display: flex;
+  align-items: flex-start;
+}
+
+.contact-form .consent input {
+  width: auto;
+  margin-right: 0.5rem;
+}
+
+.contact-form button {
+  margin-top: 0.5rem;
+}
+
+.privacy-note {
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
 }

--- a/blog.html
+++ b/blog.html
@@ -8,13 +8,17 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" href="/favicon.ico">
 </head>
 <body>
   <nav class="site-nav" aria-label="Main Navigation">
     <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
     <ul id="navMenu" class="nav-menu">
       <li><a href="index.html#home">Home</a></li>
-      <li><a href="index.html#watch">Watch</a></li>
       <li><a href="index.html#about">About</a></li>
       <li><a href="index.html#contact">Contact</a></li>
     </ul>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact | Kraftech Consulting</title>
+  <meta name="description" content="Start your automation opportunity review.">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" href="/favicon.ico">
+</head>
+<body>
+  <nav class="site-nav" aria-label="Main Navigation">
+    <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
+    <ul id="navMenu" class="nav-menu">
+      <li><a href="index.html#home">Home</a></li>
+      <li><a href="index.html#about">About</a></li>
+      <li><a href="index.html#contact">Contact</a></li>
+    </ul>
+  </nav>
+  <main class="container">
+    <section id="form" class="contact-form">
+      <h1>Start Your Automation Opportunity Review</h1>
+      <form action="https://formspree.io/f/xovlopqq" method="POST">
+        <input type="hidden" name="_redirect" value="/thank-you.html">
+        <div style="position:absolute; left:-5000px;">
+          <label for="website2">Website</label>
+          <input type="text" id="website2" name="website2" tabindex="-1">
+        </div>
+        <div class="form-group">
+          <label for="name">Full Name</label>
+          <input type="text" id="name" name="name" required>
+        </div>
+        <div class="form-group">
+          <label for="email">Business Email</label>
+          <input type="email" id="email" name="email" required>
+        </div>
+        <div class="form-group">
+          <label for="company">Company</label>
+          <input type="text" id="company" name="company">
+        </div>
+        <div class="form-group">
+          <label for="website">Website/Domain</label>
+          <input type="url" id="website" name="website">
+        </div>
+        <div class="form-group">
+          <label for="automation">What would you like to automate first?</label>
+          <textarea id="automation" name="automation" required></textarea>
+        </div>
+        <div class="form-group">
+          <label for="team">Approx. team size</label>
+          <select id="team" name="team">
+            <option value="">Select</option>
+            <option>1–10</option>
+            <option>11–50</option>
+            <option>51–200</option>
+            <option>200+</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="timeline">Timeline</label>
+          <select id="timeline" name="timeline">
+            <option value="">Select</option>
+            <option>ASAP</option>
+            <option>30–60 days</option>
+            <option>60–90 days</option>
+            <option>Planning</option>
+          </select>
+        </div>
+        <div class="form-group consent">
+          <input type="checkbox" id="consent" name="consent" required>
+          <label for="consent">I agree to be contacted about this inquiry.</label>
+        </div>
+        <button type="submit" class="cta-button">Send Inquiry</button>
+        <p class="privacy-note">We respect your privacy. Your information will only be used to respond to this inquiry.</p>
+      </form>
+    </section>
+  </main>
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 J. Adam Kraft – Kraftech Consulting</p>
+    </div>
+  </footer>
+  <div class="sticky-footer">
+    <a id="stickyCta" href="index.html#video-series">⚡ Get Our Automation Stack – Watch the Video Series</a>
+  </div>
+  <script>
+    const toggle = document.querySelector('.nav-toggle');
+    const menu = document.getElementById('navMenu');
+    if (toggle && menu) {
+      toggle.addEventListener('click', () => {
+        menu.classList.toggle('open');
+        const expanded = toggle.getAttribute('aria-expanded') === 'true' || false;
+        toggle.setAttribute('aria-expanded', !expanded);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/example-post-title.html
+++ b/example-post-title.html
@@ -8,15 +8,19 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" href="/favicon.ico">
 </head>
 <body>
   <nav class="site-nav" aria-label="Main Navigation">
     <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
     <ul id="navMenu" class="nav-menu">
-      <li><a href="/#home">Home</a></li>
-      <li><a href="/#watch">Watch</a></li>
-      <li><a href="/#about">About</a></li>
-      <li><a href="/#contact">Contact</a></li>
+      <li><a href="index.html#home">Home</a></li>
+      <li><a href="index.html#about">About</a></li>
+      <li><a href="index.html#contact">Contact</a></li>
     </ul>
   </nav>
   <header class="page-header">

--- a/index.html
+++ b/index.html
@@ -8,13 +8,17 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" href="/favicon.ico">
 </head>
 <body>
   <nav class="site-nav" aria-label="Main Navigation">
     <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
     <ul id="navMenu" class="nav-menu">
       <li><a href="#home">Home</a></li>
-      <li><a href="#watch">Watch</a></li>
       <li><a href="#about">About</a></li>
       <li><a href="#contact">Contact</a></li>
     </ul>
@@ -29,9 +33,14 @@
     ></iframe>
     <div class="overlay"></div>
     <div class="container hero-content">
-      <h1>AI Workflows. Automated Success.</h1>
-      <p class="subheadline">We don't just talk about automation. We run on it.</p>
-      <a class="cta-button" href="#video-series">Watch How We Do It</a>
+      <h1>Fractional CTO for Automation &amp; AI</h1>
+      <p class="subheadline">Helping SMBs reclaim time, cut costs, and protect compliance — with automation strategies that deliver ROI fast.</p>
+      <ul class="value-bullets">
+        <li>Pinpoint automation opportunities in your business in just 30 minutes</li>
+        <li>Save hours each week with streamlined workflows</li>
+        <li>Get CTO-level guidance without the full-time hire</li>
+      </ul>
+      <a class="cta-button" href="/contact.html#form">👉 Book Your Free Automation Opportunity Review</a>
     </div>
   </header>
 

--- a/kraftech-co-gen-x-tech.html
+++ b/kraftech-co-gen-x-tech.html
@@ -8,15 +8,19 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" href="/favicon.ico">
 </head>
 <body>
   <nav class="site-nav" aria-label="Main Navigation">
     <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
     <ul id="navMenu" class="nav-menu">
-      <li><a href="/#home">Home</a></li>
-      <li><a href="/#watch">Watch</a></li>
-      <li><a href="/#about">About</a></li>
-      <li><a href="/#contact">Contact</a></li>
+      <li><a href="index.html#home">Home</a></li>
+      <li><a href="index.html#about">About</a></li>
+      <li><a href="index.html#contact">Contact</a></li>
     </ul>
   </nav>
   <header class="page-header">

--- a/templates/post-template.html
+++ b/templates/post-template.html
@@ -8,15 +8,19 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" href="/favicon.ico">
 </head>
 <body>
   <nav class="site-nav" aria-label="Main Navigation">
     <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
     <ul id="navMenu" class="nav-menu">
-      <li><a href="/#home">Home</a></li>
-      <li><a href="/#watch">Watch</a></li>
-      <li><a href="/#about">About</a></li>
-      <li><a href="/#contact">Contact</a></li>
+      <li><a href="index.html#home">Home</a></li>
+      <li><a href="index.html#about">About</a></li>
+      <li><a href="index.html#contact">Contact</a></li>
     </ul>
   </nav>
   <header class="page-header">


### PR DESCRIPTION
## Summary
- Replaced homepage hero messaging with ROI-focused copy, value bullets and CTA to contact page.
- Removed "Watch" from site navigation and wired favicons across pages and templates.
- Added conversion-focused contact page with Formspree form and basic form styling.

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5ec4cf2408322aede6a70231d5c3e