### PR TITLE
Add first featured blog post, About page, and scheduled rebuild

### DIFF
--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -1,0 +1,49 @@
+name: Scheduled blog rebuild
+
+on:
+  schedule:
+    - cron: "17 9 * * 1-5"   # Weekdays 09:17 UTC; adjust as desired
+  workflow_dispatch:
+  push:
+    paths:
+      - "content/blog/**"
+      - "scripts/**"
+      - "templates/**"
+      - "index.html"
+      - "blog.html"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install deps
+        run: |
+          npm ci || npm i
+
+      - name: Build blog & homepage
+        run: node scripts/build-blog.js
+
+      - name: Commit generated pages (if changed)
+        run: |
+          git config user.name "kraftech-bot"
+          git config user.email "bot@users.noreply.github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(ci): scheduled rebuild of blog & homepage"
+            git push
+          else
+            echo "No changes to commit."
+          fi

--- a/about.html
+++ b/about.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About | Kraftech Consulting</title>
+  <meta name="description" content="Fractional CTO & Automation Architect—protecting uptime, compliance, and ROI.">
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+  <nav class="site-nav" aria-label="Main Navigation">
+    <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
+    <ul id="navMenu" class="nav-menu">
+      <li><a href="index.html#home">Home</a></li>
+      <li><a href="/about.html" aria-current="page">About</a></li>
+      <li><a href="/blog.html">Blog</a></li>
+      <li><a href="index.html#contact">Contact</a></li>
+    </ul>
+  </nav>
+
+  <header class="page-header">
+    <div class="container">
+      <h1>Fractional CTO & Automation Architect</h1>
+      <p class="subheadline">Protecting uptime, compliance, and ROI for businesses that can’t afford to fail.</p>
+    </div>
+  </header>
+
+  <main class="container">
+    <section>
+      <h2>Why Companies Hire Me</h2>
+      <p>I’m the translation layer between executives and specialists. Business hears clarity and confidence; technical teams get a partner who won’t micromanage. Momentum stays. Risk drops. Trust compounds.</p>
+      <ul class="value-bullets">
+        <li>$20,000/day fine prevented — cameras restored and timestamps corrected by the deadline</li>
+        <li>Zero-downtime bankruptcy recovery — Starlink deployed to bridge a 30-day ISP gap</li>
+        <li>Connectivity crisis resolved — failing wireless link replaced with fiber; outages eliminated</li>
+        <li>Vendor accountability win — compliance retention fixed without unnecessary hardware</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>How I Work</h2>
+      <ul>
+        <li><strong>Executive Alignment:</strong> tech strategy mapped to business goals and risk tolerance</li>
+        <li><strong>MSP Complement:</strong> I don’t replace your MSP—I make sure you get results from them</li>
+        <li><strong>Automation & AI:</strong> identify, pilot, and scale workflows that save hours every week</li>
+        <li><strong>Documentation & Accountability:</strong> decisions and outcomes tracked; vendors deliver</li>
+      </ul>
+      <p class="note">Service-first leadership; client needs above ego or politics.</p>
+    </section>
+
+    <section>
+      <h2>Representative Wins</h2>
+      <ul>
+        <li>Compliance footage delivered to regulators; supported arrests in illicit operations</li>
+        <li>Rural facility compliance via satellite-backed camera system</li>
+        <li>Post-vendor dispute access restored across multi-NVR environments</li>
+      </ul>
+      <p><a href="/blog.html" rel="noopener noreferrer">See recent posts and practical breakdowns →</a></p>
+    </section>
+
+    <section>
+      <h2>Let’s Talk</h2>
+      <p>Need a right-sized CTO who finds a way instead of saying why it can’t be done? I offer a free Automation Opportunity Review to surface fast ROI.</p>
+      <p><a class="cta-button" href="/contact.html#form">Book your review</a></p>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 J. Adam Kraft – Kraftech Consulting</p>
+    </div>
+  </footer>
+
+  <script>
+    const toggle = document.querySelector('.nav-toggle');
+    const menu = document.getElementById('navMenu');
+    if (toggle && menu) {
+      toggle.addEventListener('click', () => {
+        menu.classList.toggle('open');
+        const expanded = toggle.getAttribute('aria-expanded') === 'true' || false;
+        toggle.setAttribute('aria-expanded', !expanded);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -19,8 +19,9 @@
     <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
     <ul id="navMenu" class="nav-menu">
       <li><a href="index.html#home">Home</a></li>
-      <li><a href="index.html#about">About</a></li>
-      <li><a href="/contact.html#form">Contact</a></li>
+      <li><a href="/about.html">About</a></li>
+      <li><a href="/blog.html" aria-current="page">Blog</a></li>
+      <li><a href="index.html#contact">Contact</a></li>
     </ul>
   </nav>
   <header class="page-header">
@@ -32,6 +33,10 @@
 
   <main class="container">
     <ul class="post-list">
+      <li class="featured">
+        <a href="why-your-business-needs-a-fractional-cto-now-more-than-ever.html">Why Your Business Needs a Fractional CTO (Now More Than Ever)</a>
+        <span class="post-date">Sep 10, 2025</span> <span class="badge">Featured</span>
+      </li>
       <li class="featured">
         <a href="kraftech-co-gen-x-tech.html">kraftech.co | Gen X Tech</a>
         <span class="post-date">Aug 15, 2025</span> <span class="badge">Featured</span>

--- a/content/blog/why-your-business-needs-a-fractional-cto.md
+++ b/content/blog/why-your-business-needs-a-fractional-cto.md
@@ -1,0 +1,77 @@
+---
+title: "Why Your Business Needs a Fractional CTO (Now More Than Ever)"
+date: 2025-09-10
+tags: [fractional-cto, strategy, ai, automation]
+summary: |
+  Most businesses rely on MSPs to keep operations running. But an MSP isn’t a CTO. Here’s why a Fractional CTO is essential for aligning IT strategy with business growth—and why now is the time to invest.
+featured: true
+published: true
+---
+
+# Why Your Business Needs a Fractional CTO (Now More Than Ever)
+
+Most executives think of IT as a cost center. They hire a Managed Service Provider (MSP), hand over the keys, and hope things just work. And in fairness, MSPs are critical. They keep the lights on, they fix things when they break, and they make sure your email keeps flowing.  
+
+But here’s the problem: **an MSP is not your CTO.**  
+
+I know, because I’ve been on both sides of that fence—running an MSP and later overseeing MSPs as a Fractional CTO. And I can tell you this with confidence: if you’re relying on your MSP to chart the long-term vision for your technology, you’re already behind.
+
+---
+
+## The Inherent Contradiction of MSPs
+
+MSPs are in business to make money. And most of that money is tied to *time spent fixing problems*.  
+Their incentives are about resolution, not reinvention.  
+
+- They’re paid to keep operations running, not to align tech with your business strategy.  
+- They have no direct stake in whether your IT roadmap supports your growth.  
+- They aren’t rewarded for introducing automation or AI workflows that reduce their billable hours.  
+
+None of this makes MSPs “bad.” In fact, they’re doing exactly what they should be doing. But it does mean **you’re missing the leadership function that connects technology decisions to business outcomes.**
+
+---
+
+## When “Good Enough” Costs You
+
+Too often, companies live with IT that’s duct-taped together—secure *enough*, efficient *enough*, backed up *enough*.  
+
+The problem isn’t negligence. It’s that no one is asking the higher-level questions:  
+
+- *Is this the best way to protect sensitive data against today’s threats?*  
+- *Can these workflows be automated instead of manually repeated every week?*  
+- *What opportunities are we leaving on the table by doing things “the way they’ve always been done”?*  
+
+The difference between *good enough* IT and strategic IT can be the difference between staying afloat and pulling ahead.
+
+---
+
+## The Role of a Fractional CTO
+
+A Fractional CTO doesn’t replace your MSP. They complement it.  
+
+Think of it this way:  
+- **MSPs keep the car running.**  
+- **A Fractional CTO decides where the car should go.**  
+
+Here’s what that looks like in practice:  
+- Aligning IT strategy with executive goals.  
+- Vetting whether your MSP’s practices actually match your risk tolerance.  
+- Identifying automation opportunities that save hours every week.  
+- Bringing AI into the conversation before your competitors do.  
+
+---
+
+## Why Now?
+
+AI and automation are at an inflection point. Early adopters are already reshaping industries by cutting costs, speeding up workflows, and reimagining customer experiences.  
+
+If you don’t have someone in the room—*your room*—connecting these tools to your business model, you’re relying on luck. And luck isn’t a strategy.  
+
+Now is the time to invest in a Fractional CTO. Not just to avoid mistakes, but to capture opportunities your MSP will never put on the table.  
+
+---
+
+### Final Thought
+
+MSPs keep the engine running. A Fractional CTO makes sure you’re in the right race.  
+

--- a/example-post-title.html
+++ b/example-post-title.html
@@ -19,8 +19,9 @@
     <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
     <ul id="navMenu" class="nav-menu">
       <li><a href="index.html#home">Home</a></li>
-      <li><a href="index.html#about">About</a></li>
-      <li><a href="/contact.html#form">Contact</a></li>
+      <li><a href="/about.html">About</a></li>
+      <li><a href="/blog.html">Blog</a></li>
+      <li><a href="index.html#contact">Contact</a></li>
     </ul>
   </nav>
   <header class="page-header">

--- a/index.html
+++ b/index.html
@@ -19,7 +19,8 @@
     <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
     <ul id="navMenu" class="nav-menu">
       <li><a href="#home">Home</a></li>
-      <li><a href="#about">About</a></li>
+      <li><a href="/about.html">About</a></li>
+      <li><a href="/blog.html">Blog</a></li>
       <li><a href="/contact.html#form">Contact</a></li>
     </ul>
   </nav>
@@ -47,24 +48,25 @@
   <section id="about" class="about">
     <div class="container">
       <h2>Build Smarter Systems</h2>
-      <p>From strategy to implementation, I help small and mid-sized teams automate the boring stuff and ship faster with AI—without breaking what already works. Clear roadmaps, secure integrations, and measurable outcomes.</p>
-    </div>
-  </section>
-
-  <section class="trust">
-    <div class="container">
-      <blockquote>“Kraftech has bailed us out and saved us money countless times. We never have to worry about tech today or what's coming next and we stay productive.” – <span class="client">COO</span></blockquote>
+      <p>You don’t need a “yes-but” hacker. You need an IT leader who listens, translates, and delivers. I align executive goals with practical, right-sized tech—protecting uptime, compliance, and ROI. I bridge specialists and decision-makers so projects move, vendors perform, and money isn’t wasted.</p>
+      <ul class="value-bullets">
+        <li>$20k/day fine avoided by restoring compliance-critical cameras on deadline</li>
+        <li>Downtime averted during bankruptcy via Starlink failover</li>
+        <li>Failing wireless replaced with fiber; vendor retention gaps fixed without waste</li>
+      </ul>
+      <p><a href="/about.html" rel="noopener noreferrer">How I work</a> · <a href="/blog.html" rel="noopener noreferrer">Practical wins on the blog</a></p>
     </div>
   </section>
 
   <section id="video-series" class="video-series">
     <div class="container">
-      <h2>kraftech.co | Gen X Tech</h2>
+      <h2>Why Your Business Needs a Fractional CTO (Now More Than Ever)</h2>
       <div class="video-wrapper" style="position:relative;padding-top:56.25%;">
         <iframe src="https://iframe.videodelivery.net/0d98c6ca61963ec7ebef82d7bf2636d0" style="position:absolute;top:0;left:0;width:100%;height:100%;" allow="autoplay; encrypted-media" allowfullscreen frameborder="0"></iframe>
       </div>
-      <p>A Gen-X journey from solar calculator to modern AI & automation—created with AI video (Veo 3) and edited in iMovie; ending on kraftech.co.</p>
-      <p style="font-size:0.9rem;"><a href="/blog" rel="noopener noreferrer">See more case studies &rarr;</a></p>
+      <p>Most businesses rely on MSPs to keep operations running. But an MSP isn’t a CTO. Here’s why a Fractional CTO is essential for aligning IT strategy with business growth—and why now is the time to invest.
+</p>
+      <p><a href="/why-your-business-needs-a-fractional-cto-now-more-than-ever.html" rel="noopener noreferrer">Read more &rarr;</a></p>
     </div>
   </section>
 

--- a/kraftech-co-gen-x-tech.html
+++ b/kraftech-co-gen-x-tech.html
@@ -19,8 +19,9 @@
     <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
     <ul id="navMenu" class="nav-menu">
       <li><a href="index.html#home">Home</a></li>
-      <li><a href="index.html#about">About</a></li>
-      <li><a href="/contact.html#form">Contact</a></li>
+      <li><a href="/about.html">About</a></li>
+      <li><a href="/blog.html">Blog</a></li>
+      <li><a href="index.html#contact">Contact</a></li>
     </ul>
   </nav>
   <header class="page-header">

--- a/scripts/build-blog.js
+++ b/scripts/build-blog.js
@@ -135,13 +135,16 @@ listHtml = listHtml.replace(/<ul class="post-list">[\s\S]*?<\/ul>/, `<ul class="
 fs.writeFileSync(blogListPage, listHtml, 'utf8');
 
 if (fs.existsSync(indexPage)) {
-  const featuredPost = posts.find(p => p.featured && p.video && /^https:\/\/iframe\.videodelivery\.net\//.test(p.video));
+  const featuredPost = posts.find(p => p.featured);
   if (featuredPost) {
     let indexHtml = fs.readFileSync(indexPage, 'utf8');
     const summaryHtml = featuredPost.summary ? `      <p>${featuredPost.summary}</p>\n` : '';
-    const seeMore = hadBlogList ? `      <p style="font-size:0.9rem;"><a href="/blog" rel="noopener noreferrer">See more case studies &rarr;</a></p>\n` : '';
-    const videoEmbed = `      <div class="video-wrapper" style="position:relative;padding-top:56.25%;">\n        <iframe src="${featuredPost.video}" style="position:absolute;top:0;left:0;width:100%;height:100%;" allow="autoplay; encrypted-media" allowfullscreen frameborder="0"></iframe>\n      </div>\n`;
-    const replacement = `    <div class="container">\n      <h2>${featuredPost.title}</h2>\n${videoEmbed}${summaryHtml}${seeMore}    </div>`;
+    const videoSrc = (featuredPost.video && /^https:\/\/iframe\.videodelivery\.net\//.test(featuredPost.video))
+      ? featuredPost.video
+      : 'https://iframe.videodelivery.net/0d98c6ca61963ec7ebef82d7bf2636d0';
+    const videoEmbed = `      <div class="video-wrapper" style="position:relative;padding-top:56.25%;">\n        <iframe src="${videoSrc}" style="position:absolute;top:0;left:0;width:100%;height:100%;" allow="autoplay; encrypted-media" allowfullscreen frameborder="0"></iframe>\n      </div>\n`;
+    const readMore = `      <p><a href="/${featuredPost.file}" rel="noopener noreferrer">Read more &rarr;</a></p>\n`;
+    const replacement = `    <div class="container">\n      <h2>${featuredPost.title}</h2>\n${videoEmbed}${summaryHtml}${readMore}    </div>`;
     indexHtml = indexHtml.replace(/<section id="video-series" class="video-series">[\s\S]*?<\/section>/, `<section id="video-series" class="video-series">\n${replacement}\n  </section>`);
     fs.writeFileSync(indexPage, indexHtml, 'utf8');
   }

--- a/templates/post-template.html
+++ b/templates/post-template.html
@@ -19,8 +19,9 @@
     <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
     <ul id="navMenu" class="nav-menu">
       <li><a href="index.html#home">Home</a></li>
-      <li><a href="index.html#about">About</a></li>
-      <li><a href="/contact.html#form">Contact</a></li>
+      <li><a href="/about.html">About</a></li>
+      <li><a href="/blog.html">Blog</a></li>
+      <li><a href="index.html#contact">Contact</a></li>
     </ul>
   </nav>
   <header class="page-header">

--- a/why-your-business-needs-a-fractional-cto-now-more-than-ever.html
+++ b/why-your-business-needs-a-fractional-cto-now-more-than-ever.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Why Your Business Needs a Fractional CTO (Now More Than Ever) | Kraftech Consulting</title>
+  <meta name="description" content="Most businesses rely on MSPs to keep operations running. But an MSP isn’t a CTO. Here’s why a Fractional CTO is essential for aligning IT strategy with business growth—and why now is the time to invest.
+">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Text:wght@400;700&family=Cormorant+Garamond:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" href="/favicon.ico">
+</head>
+<body>
+  <nav class="site-nav" aria-label="Main Navigation">
+    <button class="nav-toggle" aria-controls="navMenu" aria-expanded="false">&#9776;</button>
+    <ul id="navMenu" class="nav-menu">
+      <li><a href="index.html#home">Home</a></li>
+      <li><a href="/about.html">About</a></li>
+      <li><a href="/blog.html">Blog</a></li>
+      <li><a href="index.html#contact">Contact</a></li>
+    </ul>
+  </nav>
+  <header class="page-header">
+    <div class="container">
+      <h1>Why Your Business Needs a Fractional CTO (Now More Than Ever)</h1>
+      <p class="post-date">Sep 10, 2025 • Tags: fractional-cto, strategy, ai, automation</p>
+    </div>
+  </header>
+
+  <main class="container">
+    <p>Most businesses rely on MSPs to keep operations running. But an MSP isn’t a CTO. Here’s why a Fractional CTO is essential for aligning IT strategy with business growth—and why now is the time to invest.
+</p>
+    
+    <div class="post-body"><h1>Why Your Business Needs a Fractional CTO (Now More Than Ever)</h1>
+<p>Most executives think of IT as a cost center. They hire a Managed Service Provider (MSP), hand over the keys, and hope things just work. And in fairness, MSPs are critical. They keep the lights on, they fix things when they break, and they make sure your email keeps flowing.</p>
+<p>But here’s the problem: <strong>an MSP is not your CTO.</strong></p>
+<p>I know, because I’ve been on both sides of that fence—running an MSP and later overseeing MSPs as a Fractional CTO. And I can tell you this with confidence: if you’re relying on your MSP to chart the long-term vision for your technology, you’re already behind.</p>
+<hr />
+<h2>The Inherent Contradiction of MSPs</h2>
+<p>MSPs are in business to make money. And most of that money is tied to <em>time spent fixing problems</em>.<br />
+Their incentives are about resolution, not reinvention.</p>
+<ul>
+<li>They’re paid to keep operations running, not to align tech with your business strategy.</li>
+<li>They have no direct stake in whether your IT roadmap supports your growth.</li>
+<li>They aren’t rewarded for introducing automation or AI workflows that reduce their billable hours.</li>
+</ul>
+<p>None of this makes MSPs “bad.” In fact, they’re doing exactly what they should be doing. But it does mean <strong>you’re missing the leadership function that connects technology decisions to business outcomes.</strong></p>
+<hr />
+<h2>When “Good Enough” Costs You</h2>
+<p>Too often, companies live with IT that’s duct-taped together—secure <em>enough</em>, efficient <em>enough</em>, backed up <em>enough</em>.</p>
+<p>The problem isn’t negligence. It’s that no one is asking the higher-level questions:</p>
+<ul>
+<li><em>Is this the best way to protect sensitive data against today’s threats?</em></li>
+<li><em>Can these workflows be automated instead of manually repeated every week?</em></li>
+<li><em>What opportunities are we leaving on the table by doing things “the way they’ve always been done”?</em></li>
+</ul>
+<p>The difference between <em>good enough</em> IT and strategic IT can be the difference between staying afloat and pulling ahead.</p>
+<hr />
+<h2>The Role of a Fractional CTO</h2>
+<p>A Fractional CTO doesn’t replace your MSP. They complement it.</p>
+<p>Think of it this way:</p>
+<ul>
+<li><strong>MSPs keep the car running.</strong></li>
+<li><strong>A Fractional CTO decides where the car should go.</strong></li>
+</ul>
+<p>Here’s what that looks like in practice:</p>
+<ul>
+<li>Aligning IT strategy with executive goals.</li>
+<li>Vetting whether your MSP’s practices actually match your risk tolerance.</li>
+<li>Identifying automation opportunities that save hours every week.</li>
+<li>Bringing AI into the conversation before your competitors do.</li>
+</ul>
+<hr />
+<h2>Why Now?</h2>
+<p>AI and automation are at an inflection point. Early adopters are already reshaping industries by cutting costs, speeding up workflows, and reimagining customer experiences.</p>
+<p>If you don’t have someone in the room—<em>your room</em>—connecting these tools to your business model, you’re relying on luck. And luck isn’t a strategy.</p>
+<p>Now is the time to invest in a Fractional CTO. Not just to avoid mistakes, but to capture opportunities your MSP will never put on the table.</p>
+<hr />
+<h3>Final Thought</h3>
+<p>MSPs keep the engine running. A Fractional CTO makes sure you’re in the right race.</p>
+</div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 J. Adam Kraft – Kraftech Consulting</p>
+    </div>
+  </footer>
+  <script>
+    const toggle = document.querySelector('.nav-toggle');
+    const menu = document.getElementById('navMenu');
+    if (toggle && menu) {
+      toggle.addEventListener('click', () => {
+        menu.classList.toggle('open');
+        const expanded = toggle.getAttribute('aria-expanded') === 'true' || false;
+        toggle.setAttribute('aria-expanded', !expanded);
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add featured blog post on fractional CTO, wired into homepage
- refresh navigation and About section, publish standalone /about.html
- default homepage video to commercial when latest featured post lacks one and schedule daily rebuilds

## Testing
- `node scripts/build-blog.js`

------
https://chatgpt.com/codex/tasks/task_e_68c1dd5645d88322893f1e28be7eec7d